### PR TITLE
2021/12/12 [Hypernova] - Theme based zig-zag background

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "hamburgers": "^1.1.3",
     "i18next": "^21.5.4",
     "lodash-es": "^4.17.21",
+    "mix-color": "^1.1.2",
     "notistack": "^2.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/frontend/src/MUIConfig.ts
+++ b/frontend/src/MUIConfig.ts
@@ -1,4 +1,5 @@
 import { createTheme } from '@mui/material/styles';
+import mixColor from 'mix-color';
 import image from 'psyw_screen_mfgg.png';
 
 const theme = createTheme({
@@ -35,6 +36,10 @@ const theme = createTheme({
 });
 export default theme;
 
+const veryDark = mixColor('#000', theme.palette.primary.dark, 0.5);
+const veryDarkBG = mixColor('#000', theme.palette.primary.dark, 0.4);
+const veryError = mixColor('#000', theme.palette.error.main, 0.5);
+const veryErrorBG = mixColor('#000', theme.palette.error.main, 0.4);
 export const styles: { [key: string]: React.CSSProperties } = {
   bigText: {
     fontWeight: 600,
@@ -83,9 +88,15 @@ export const styles: { [key: string]: React.CSSProperties } = {
     transition: '200ms linear all',
   },
   zigzagBG: {
-    backgroundColor: '#000043',
-    backgroundImage:
-      'linear-gradient(135deg, #000356 25%, transparent 25%), linear-gradient(225deg, #000356 25%, transparent 25%), linear-gradient(45deg, #000356 25%, transparent 25%), linear-gradient(315deg, #000356 25%, #000043 25%)',
+    backgroundColor: veryDarkBG,
+    backgroundImage: `linear-gradient(135deg, ${veryDark} 25%, transparent 25%), linear-gradient(225deg, ${veryDark} 25%, transparent 25%), linear-gradient(45deg, ${veryDark} 25%, transparent 25%), linear-gradient(315deg, ${veryDark} 25%, ${veryDarkBG} 25%)`,
+    backgroundPosition: '40px 0, 40px 0, 0 0, 0 0',
+    backgroundSize: '80px 80px',
+    backgroundRepeat: 'repeat',
+  },
+  zigzagBGError: {
+    backgroundColor: veryErrorBG,
+    backgroundImage: `linear-gradient(135deg, ${veryError} 25%, transparent 25%), linear-gradient(225deg, ${veryError} 25%, transparent 25%), linear-gradient(45deg, ${veryError} 25%, transparent 25%), linear-gradient(315deg, ${veryError} 25%, ${veryErrorBG} 25%)`,
     backgroundPosition: '40px 0, 40px 0, 0 0, 0 0',
     backgroundSize: '80px 80px',
     backgroundRepeat: 'repeat',

--- a/frontend/src/error/index.tsx
+++ b/frontend/src/error/index.tsx
@@ -30,7 +30,7 @@ export default function Error(props: ErrorProps) {
     <Box
       flex="1 0 auto"
       width="100%"
-      style={styles.zigzagBG}
+      style={props.error || error ? styles.zigzagBGError : styles.zigzagBG}
       display="flex"
       flexDirection="column"
       alignItems="center"
@@ -53,7 +53,12 @@ export default function Error(props: ErrorProps) {
             </Typography>
           </Box>
           <Box mx={2} my={4}>
-            <LumaButton onClick={handleGoHome} variant="contained" size="large">
+            <LumaButton
+              onClick={handleGoHome}
+              variant="contained"
+              size="large"
+              color={props.error || error ? 'error' : undefined}
+            >
               {error || props.error ? t('main.goHome') : t('main.unknown')}
             </LumaButton>
           </Box>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -11,7 +11,7 @@
     "copyright": "Mario Fan Games Galaxy, 2001 - {{year}}"
   },
   "main": {
-    "goHome": "Go Home",
+    "goHome": "Return to Home",
     "search": "Search",
     "siteName": "MFGG",
     "siteNameLong": "Mario Fan Games Galaxy",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7932,6 +7932,11 @@ mississippi@^3.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
+mix-color@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/mix-color/-/mix-color-1.1.2.tgz#aa115c74152c71d59698e7bcfa9e45da8a03a8a9"
+  integrity sha512-dl0x92sQ+cMM37GVo5MpLJfPbLxFhyqTrf6paYp/k+1rRPK1aPPPI7xajEI+GtU+eWnCsAW2Bg1q0rH1gLbI7w==
+
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"


### PR DESCRIPTION
## Description
Implement background codes so the colors are not hardcoded.

## Changes
#### Front End
- Main zig-zag background is now based on the theme primary dark color
- Error page zig-zag background is now red
#### Back-End
- N/A

## New Dependencies
- mix-color
